### PR TITLE
Feat/profile view and dark light preference

### DIFF
--- a/UniTrade/UniTrade.xcodeproj/project.pbxproj
+++ b/UniTrade/UniTrade.xcodeproj/project.pbxproj
@@ -53,6 +53,12 @@
 		F123D9B22CABC2A800FDBB2A /* FirebaseAppDistribution-Beta in Frameworks */ = {isa = PBXBuildFile; productRef = F123D9B12CABC2A800FDBB2A /* FirebaseAppDistribution-Beta */; };
 		F123D9B62CABC49800FDBB2A /* UploadProductViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F123D9B52CABC49800FDBB2A /* UploadProductViewModel.swift */; };
 		F1373C0C2CAB70E8001181DC /* UploadProductStrategies.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1373C0B2CAB70E8001181DC /* UploadProductStrategies.swift */; };
+		F1405C2D2CC46B3900FDA818 /* MyListingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1405C2C2CC46B3500FDA818 /* MyListingsView.swift */; };
+		F1405C2F2CC46BC800FDA818 /* MyOrdersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1405C2E2CC46BC700FDA818 /* MyOrdersView.swift */; };
+		F1405C312CC473C300FDA818 /* LightDarkModeSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1405C302CC473C300FDA818 /* LightDarkModeSettingsView.swift */; };
+		F1405C332CC57DEE00FDA818 /* ModeSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1405C322CC57DEE00FDA818 /* ModeSettings.swift */; };
+		F14716D62CC46249007D673E /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F14716D52CC46249007D673E /* ProfileView.swift */; };
+		F14716D82CC46256007D673E /* ProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F14716D72CC46256007D673E /* ProfileViewModel.swift */; };
 		F14EB8822CBF17F700107109 /* CurrencyFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F14EB8812CBF17F700107109 /* CurrencyFormatter.swift */; };
 		F15D0DDE2CA4BFDD00CF9562 /* UploadImageButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15D0DDD2CA4BFDD00CF9562 /* UploadImageButton.swift */; };
 		F15D0DE02CA4C01D00CF9562 /* ImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15D0DDF2CA4C01D00CF9562 /* ImagePicker.swift */; };
@@ -126,6 +132,12 @@
 		8EF6EA3A2CBCDE8A003C7F0F /* CategoryName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryName.swift; sourceTree = "<group>"; };
 		F123D9B52CABC49800FDBB2A /* UploadProductViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadProductViewModel.swift; sourceTree = "<group>"; };
 		F1373C0B2CAB70E8001181DC /* UploadProductStrategies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadProductStrategies.swift; sourceTree = "<group>"; };
+		F1405C2C2CC46B3500FDA818 /* MyListingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyListingsView.swift; sourceTree = "<group>"; };
+		F1405C2E2CC46BC700FDA818 /* MyOrdersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyOrdersView.swift; sourceTree = "<group>"; };
+		F1405C302CC473C300FDA818 /* LightDarkModeSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightDarkModeSettingsView.swift; sourceTree = "<group>"; };
+		F1405C322CC57DEE00FDA818 /* ModeSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModeSettings.swift; sourceTree = "<group>"; };
+		F14716D52CC46249007D673E /* ProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
+		F14716D72CC46256007D673E /* ProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewModel.swift; sourceTree = "<group>"; };
 		F14EB8812CBF17F700107109 /* CurrencyFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyFormatter.swift; sourceTree = "<group>"; };
 		F15D0DDD2CA4BFDD00CF9562 /* UploadImageButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadImageButton.swift; sourceTree = "<group>"; };
 		F15D0DDF2CA4C01D00CF9562 /* ImagePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePicker.swift; sourceTree = "<group>"; };
@@ -230,6 +242,12 @@
 		F1D5BEA02CA316A100C9DA71 /* UniTrade */ = {
 			isa = PBXGroup;
 			children = (
+				F1405C322CC57DEE00FDA818 /* ModeSettings.swift */,
+				F1405C302CC473C300FDA818 /* LightDarkModeSettingsView.swift */,
+				F1405C2E2CC46BC700FDA818 /* MyOrdersView.swift */,
+				F1405C2C2CC46B3500FDA818 /* MyListingsView.swift */,
+				F14716D72CC46256007D673E /* ProfileViewModel.swift */,
+				F14716D52CC46249007D673E /* ProfileView.swift */,
 				4CD857C62CBFA23F0046F512 /* CrashLogger.swift */,
 				4CD857C42CBF7E260046F512 /* ListingItemViewModel.swift */,
 				4CD857C22CBF7CD30046F512 /* CurrencyDecorator.swift */,
@@ -469,10 +487,12 @@
 				4C3D480E2CBF7B390080F6AD /* BasePrice.swift in Sources */,
 				F18F18ED2CA4840C005C4A78 /* TabViewIcon.swift in Sources */,
 				F1D5BF722CA369D200C9DA71 /* MainView.swift in Sources */,
+				F1405C2F2CC46BC800FDA818 /* MyOrdersView.swift in Sources */,
 				4CF004E52CAB20010001FF53 /* SearchandFilterBar.swift in Sources */,
 				4C6726A72CACDAA0007B1FB6 /* ProductCategoryGroupManager.swift in Sources */,
 				4C8DC6D32CBC1B990034A352 /* NumericTextField.swift in Sources */,
 				F1D5BF742CA36A9E00C9DA71 /* TemplateView.swift in Sources */,
+				F1405C332CC57DEE00FDA818 /* ModeSettings.swift in Sources */,
 				8E3557CE2CADAC2E00FD012C /* User.swift in Sources */,
 				F18F18F12CA4A268005C4A78 /* UploadProductView.swift in Sources */,
 				8E48C6262CBF6B60003F3EB4 /* SplashScreenView.swift in Sources */,
@@ -488,6 +508,7 @@
 				F1D5BED42CA3412C00C9DA71 /* ButtonWithIcon.swift in Sources */,
 				8E3557D82CADFDD000FD012C /* FirstTimeUserView.swift in Sources */,
 				4C3D48122CBF7B8E0080F6AD /* FormatDecorator.swift in Sources */,
+				F14716D82CC46256007D673E /* ProfileViewModel.swift in Sources */,
 				4C3D480C2CBF7B220080F6AD /* Price.swift in Sources */,
 				4C3D48102CBF7B820080F6AD /* PriceDecorator.swift in Sources */,
 				8E3557CC2CAD18AB00FD012C /* LoginViewModel.swift in Sources */,
@@ -503,12 +524,15 @@
 				4CB6E95E2CAB85AC001CE679 /* CategoryScroll.swift in Sources */,
 				4CB6E9642CAB8C09001CE679 /* CategoryItemView.swift in Sources */,
 				4C8DC6D52CBC3EF40034A352 /* FontTransformerUI.swift in Sources */,
+				F1405C312CC473C300FDA818 /* LightDarkModeSettingsView.swift in Sources */,
 				4CF004E32CA8D33F0001FF53 /* ListingItemView.swift in Sources */,
 				4CF3C14A2CABC1B30091A474 /* FilterView.swift in Sources */,
 				F1D5BEA22CA316A100C9DA71 /* UniTradeApp.swift in Sources */,
+				F14716D62CC46249007D673E /* ProfileView.swift in Sources */,
 				F14EB8822CBF17F700107109 /* CurrencyFormatter.swift in Sources */,
 				F1D5BED22CA31DE700C9DA71 /* ChooseUploadTypeView.swift in Sources */,
 				4CD857C72CBFA23F0046F512 /* CrashLogger.swift in Sources */,
+				F1405C2D2CC46B3900FDA818 /* MyListingsView.swift in Sources */,
 				4C32BA242CACCDBF0060EB5A /* Product.swift in Sources */,
 				4C32BA262CACCDD00060EB5A /* ExplorerViewModel.swift in Sources */,
 			);

--- a/UniTrade/UniTrade/ExplorerViewModel.swift
+++ b/UniTrade/UniTrade/ExplorerViewModel.swift
@@ -50,7 +50,7 @@ class ExplorerViewModel: ObservableObject {
             
             guard let data = document?.data(),
                   let categories = data["categories"] as? [String] else {
-                print("⚠️ No 'For You' categories found for user.")
+                print("⚠️ No 'For You' categories found for user with id", user.uid)
                 completion(false)
                 return
             }

--- a/UniTrade/UniTrade/LightDarkModeSettingsView.swift
+++ b/UniTrade/UniTrade/LightDarkModeSettingsView.swift
@@ -1,0 +1,108 @@
+//
+//  LightDarkModeSettingsView.swift
+//  UniTrade
+//
+//  Created by Federico Melo Barrero on 19/10/24.
+//
+
+import SwiftUI
+
+struct LightDarkModeSettingsView: View {
+    @EnvironmentObject var modeSettings: ModeSettings
+    @Environment(\.colorScheme) var colorScheme
+    
+    enum Mode {
+        case light, dark, automatic
+    }
+    
+    var body: some View {
+        List {
+            Section(header: Text("Appearance")) {
+                HStack {
+                    ModeRadioButton(
+                        image: "sun.max.fill",
+                        label: "Light",
+                        mode: .light,
+                        selectedMode: $modeSettings.selectedMode,
+                        colorScheme: colorScheme
+                    )
+                    
+                    Spacer()
+                    
+                    ModeRadioButton(
+                        image: "moon.fill",
+                        label: "Dark",
+                        mode: .dark,
+                        selectedMode: $modeSettings.selectedMode,
+                        colorScheme: colorScheme
+                    )
+                }
+                .padding(.vertical)
+                .padding(.horizontal, 50)
+            }
+            
+            // Automatic Time-Aware Toggle
+            Section(header: Text("Automatic Settings")) {
+                HStack {
+                    Toggle(isOn: Binding(
+                        get: { modeSettings.selectedMode == .automatic },
+                        set: { newValue in
+                            if newValue {
+                                modeSettings.selectedMode = .automatic
+                            } else {
+                                modeSettings.selectedMode = modeSettings.selectedMode == .automatic ? .light : modeSettings.selectedMode
+                            }
+                        }
+                    )) {
+                        Text("Automatic time-aware")
+                    }
+                    .tint(Color.DesignSystem.primary900())
+                }
+            }
+        }
+        .listStyle(InsetGroupedListStyle())
+        .navigationTitle("Light/Dark Mode")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+struct ModeRadioButton: View {
+    var image: String
+    var label: String
+    var mode: LightDarkModeSettingsView.Mode
+    @Binding var selectedMode: LightDarkModeSettingsView.Mode
+    var colorScheme: ColorScheme
+    
+    var body: some View {
+        VStack {
+            Image(systemName: image)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 70, height: 110)
+                .foregroundColor(Color.DesignSystem.dark900(for: colorScheme))
+            
+            RadioButton(isSelected: selectedMode == mode) {
+                selectedMode = mode
+            }
+            .contentShape(Rectangle())
+            
+            Text(label).padding(.vertical, 10)
+        }
+        .onTapGesture {
+            selectedMode = mode
+        }
+    }
+}
+
+struct RadioButton: View {
+    var isSelected: Bool
+    var action: () -> Void
+    
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: isSelected ? "largecircle.fill.circle" : "circle")
+                .foregroundColor(isSelected ? Color.DesignSystem.primary900() : .gray)
+        }
+        .contentShape(Rectangle())
+    }
+}

--- a/UniTrade/UniTrade/MainView.swift
+++ b/UniTrade/UniTrade/MainView.swift
@@ -72,15 +72,17 @@ struct MainView: View {
                     ExplorerView()
                 }
             case .cart:
-                TemplateView(loginViewModel: loginViewModel,name: "Cart")
+                TemplateView(name: "Cart")
             case .uploadProduct:
                 NavigationStack {
                     ChooseUploadTypeView()
                 }
             case .notifications:
-                TemplateView(loginViewModel: loginViewModel,name: "Alerts")
+                TemplateView(name: "Alerts")
             case .profile:
-                TemplateView(loginViewModel: loginViewModel,name: "Profile")
+                NavigationStack {
+                    ProfileView()
+                }
         }
     }
 }
@@ -92,4 +94,3 @@ enum BottomMenuScreenEnum: Hashable {
     case notifications
     case profile
 }
-

--- a/UniTrade/UniTrade/ModeSettings.swift
+++ b/UniTrade/UniTrade/ModeSettings.swift
@@ -1,0 +1,42 @@
+//
+//  ModeSettings.swift
+//  UniTrade
+//
+//  Created by Federico Melo Barrero on 20/10/24.
+//
+
+import SwiftUI
+
+class ModeSettings: ObservableObject {
+    @Published var selectedMode: LightDarkModeSettingsView.Mode {
+        didSet {
+            // Save the selected mode to UserDefaults whenever it changes
+            switch selectedMode {
+            case .light:
+                UserDefaults.standard.set("light", forKey: "modeSetting")
+            case .dark:
+                UserDefaults.standard.set("dark", forKey: "modeSetting")
+            case .automatic:
+                UserDefaults.standard.set("automatic", forKey: "modeSetting")
+            }
+        }
+    }
+    
+    init() {
+        // Retrieve the saved mode from UserDefaults when the app starts
+        if let savedMode = UserDefaults.standard.string(forKey: "modeSetting") {
+            switch savedMode {
+            case "light":
+                self.selectedMode = .light
+            case "dark":
+                self.selectedMode = .dark
+            case "automatic":
+                self.selectedMode = .automatic
+            default:
+                self.selectedMode = .automatic
+            }
+        } else {
+            self.selectedMode = .automatic
+        }
+    }
+}

--- a/UniTrade/UniTrade/MyListingsView.swift
+++ b/UniTrade/UniTrade/MyListingsView.swift
@@ -1,0 +1,14 @@
+//
+//  MyListingsView.swift
+//  UniTrade
+//
+//  Created by Federico Melo Barrero on 19/10/24.
+//
+
+import SwiftUI
+
+struct MyListingsView: View {
+    var body: some View {
+        TemplateView(name: "My Listings")
+    }
+}

--- a/UniTrade/UniTrade/MyOrdersView.swift
+++ b/UniTrade/UniTrade/MyOrdersView.swift
@@ -1,0 +1,14 @@
+//
+//  MyOrdersView.swift
+//  UniTrade
+//
+//  Created by Federico Melo Barrero on 19/10/24.
+//
+
+import SwiftUI
+
+struct MyOrdersView: View {
+    var body: some View {
+        TemplateView(name: "My Orders")
+    }
+}

--- a/UniTrade/UniTrade/ProfileView.swift
+++ b/UniTrade/UniTrade/ProfileView.swift
@@ -1,0 +1,108 @@
+//
+//  ProfileView.swift
+//  UniTrade
+//
+//  Created by Federico Melo Barrero on 19/10/24.
+//
+
+import SwiftUI
+import FirebaseAuth
+
+struct ProfileView: View {
+    @Environment(\.colorScheme) var colorScheme
+    @Environment(\.presentationMode) var presentationMode
+    @StateObject private var viewModel = ProfileViewModel()
+    
+    let profileImageDiameter: CGFloat = 220
+    
+    var body: some View {
+        VStack(spacing: 20) {
+            // Profile Image
+            HStack {
+                if let selectedImage = viewModel.selectedImage {
+                    Image(uiImage: selectedImage)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: profileImageDiameter, height: profileImageDiameter)
+                        .clipShape(Circle())
+                        .overlay(Circle().stroke(Color.gray, lineWidth: 2))
+                } else {
+                    UploadImageButton(
+                        height: profileImageDiameter,
+                        selectedImage: $viewModel.selectedImage,
+                        isImageFromGallery: $viewModel.isImageFromGallery
+                    )
+                    .frame(width: profileImageDiameter, height: profileImageDiameter)
+                    .clipShape(Circle())
+                }
+            }
+            
+            // User Greeting
+            if let userName = viewModel.userName {
+                HStack(spacing: 5) {
+                    Text("Hello,")
+                        .font(Font.DesignSystem.headline600)
+                        .foregroundColor(Color.DesignSystem.dark900(for: colorScheme))
+                        .multilineTextAlignment(.center)
+                    
+                    Text(userName)
+                        .font(Font.DesignSystem.headline600)
+                        .foregroundColor(Color.DesignSystem.primary900(for: colorScheme))
+                }
+            } else {
+                Text("Loading user information...")
+                    .font(Font.DesignSystem.headline600)
+                    .foregroundColor(Color.DesignSystem.dark900(for: colorScheme))
+            }
+            
+            Spacer()
+            
+            List {
+                Section {
+                    NavigationLink(destination: MyListingsView()) {
+                        Text("My Listings")
+                    }
+                    
+                    NavigationLink(destination: MyOrdersView()) {
+                        Text("My Orders")
+                    }
+                    
+                    NavigationLink(destination: LightDarkModeSettingsView()) {
+                        Text("Light/Dark Mode")
+                    }
+                }
+                .listRowBackground(Color.clear)
+            }
+            .listStyle(PlainListStyle())
+            .background(Color.clear)
+            
+            Spacer()
+            
+            // Sign Out Button
+            Button(action: {
+                viewModel.signOut { success in
+                    if success {
+                        presentationMode.wrappedValue.dismiss()
+                        print("Successfully signed out")
+                    } else {
+                        print("Failed to sign out")
+                    }
+                }
+            }) {
+                if viewModel.isSigningOut {
+                    ProgressView()
+                } else {
+                    ButtonWithIcon(text: "SIGN OUT", icon: "power")
+                }
+            }
+            .disabled(viewModel.isSigningOut)
+            .padding(.bottom, 20)
+        }
+        .onAppear {
+            viewModel.fetchUserName()
+        }
+        .padding()
+        .navigationTitle("Profile")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/UniTrade/UniTrade/ProfileViewModel.swift
+++ b/UniTrade/UniTrade/ProfileViewModel.swift
@@ -1,0 +1,51 @@
+//
+//  ProfileViewModel.swift
+//  UniTrade
+//
+//  Created by Federico Melo Barrero on 19/10/24.
+//
+
+import SwiftUI
+import FirebaseAuth
+import FirebaseFirestore
+
+class ProfileViewModel: ObservableObject {
+    @Published var selectedImage: UIImage? = nil
+    @Published var isImageFromGallery: Bool = false
+    @Published var userName: String? = nil
+    @Published var isSigningOut: Bool = false
+
+    // Inject the LoginViewModel for managing sign-in and sign-out
+    private let loginViewModel = LoginViewModel()
+
+    func fetchUserName() {
+        guard let user = Auth.auth().currentUser else {
+            print("⚠️ User is not authenticated.")
+            return
+        }
+
+        let userDocRef = Firestore.firestore().collection("users").document(user.uid)
+        print("User ID", user.uid)
+        userDocRef.getDocument { document, error in
+            if let document = document, document.exists, let data = document.data() {
+                self.userName = data["name"] as? String
+            } else {
+                print("⚠️ User document not found or error occurred.")
+            }
+        }
+    }
+
+    func signOut(completion: @escaping (Bool) -> Void) {
+        isSigningOut = true
+        loginViewModel.signOut()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { // Simulate a delay
+            self.isSigningOut = false
+            let wasSignedOut = Auth.auth().currentUser == nil
+            completion(wasSignedOut)
+        }
+    }
+
+    func toggleTheme() {
+        // Implement your theme toggle logic here.
+    }
+}

--- a/UniTrade/UniTrade/TemplateView.swift
+++ b/UniTrade/UniTrade/TemplateView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct TemplateView: View {
-    @ObservedObject var loginViewModel: LoginViewModel
     var name: String
 
     var body: some View {
@@ -17,10 +16,6 @@ struct TemplateView: View {
             Text("TODO: Implement \(name) View")
                 .font(Font.DesignSystem.headline600)
             Spacer()
-            Button("Log out") {
-                
-                loginViewModel.signOut()
-            }
         }
         .padding()
     }

--- a/UniTrade/UniTrade/UniTradeApp.swift
+++ b/UniTrade/UniTrade/UniTradeApp.swift
@@ -26,6 +26,8 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 struct UniTradeApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
     
+    @StateObject var modeSettings = ModeSettings()
+    
     var sharedModelContainer: ModelContainer = {
         let schema = Schema()
         let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
@@ -38,7 +40,7 @@ struct UniTradeApp: App {
     }()
     
     @StateObject var loginViewModel = LoginViewModel()
-    @State private var showSplash = true // State to show or hide the splash screen
+    @State private var showSplash = true
 
     func getColorSchemeBasedOnTime() -> ColorScheme {
         let currentHour = Calendar.current.component(.hour, from: Date())
@@ -60,7 +62,12 @@ struct UniTradeApp: App {
                     LoginView(loginViewModel: loginViewModel)
                 }
             }
-            .preferredColorScheme(getColorSchemeBasedOnTime()) // Apply time-based color scheme
+            .environmentObject(modeSettings)
+            .preferredColorScheme(
+                modeSettings.selectedMode == .automatic
+                ? getColorSchemeBasedOnTime()
+                : (modeSettings.selectedMode == .light ? .light : .dark)
+            )
         }
         .modelContainer(sharedModelContainer)
     }

--- a/UniTrade/UniTrade/UploadImageButton.swift
+++ b/UniTrade/UniTrade/UploadImageButton.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct UploadImageButton: View {
+    var height: CGFloat = 200
     @Environment(\.colorScheme) var colorScheme
 
     @Binding var selectedImage: UIImage?
@@ -51,7 +52,7 @@ struct UploadImageButton: View {
                             .foregroundColor(colorScheme == .light ? Color.DesignSystem.light400() : Color.DesignSystem.dark900())
                             .frame(maxWidth: .infinity)
                     }
-                    .padding(.vertical, 50)
+                    .frame(height: height)
                 }
                 .background(colorScheme == .light ? Color.DesignSystem.light100() : Color.DesignSystem.light300())
                 .cornerRadius(25)

--- a/UniTrade/UniTrade/UploadProductView.swift
+++ b/UniTrade/UniTrade/UploadProductView.swift
@@ -84,7 +84,7 @@ struct UploadProductView: View {
                     }
                 }
                 
-                UploadImageButton(selectedImage: $viewModel.selectedImage, isImageFromGallery: $viewModel.isImageFromGallery)
+                UploadImageButton(height: 160, selectedImage: $viewModel.selectedImage, isImageFromGallery: $viewModel.isImageFromGallery)
                 
                 
                 Button(action: {


### PR DESCRIPTION
# Implement profile view and dark-light mode settings view
<!-- PR Title: [Type] Brief description of changes #Issue (e.g., feat: Add user authentication #12) -->

## Description
<!-- Description of what your PR does.
- If already described in the issue, you can copy the description here. 
- If the commit messages are descriptive, you can refer to them. 
- Explain any important decisions and non-trivial changes.
-->
This PR implements a profile view along with its corresponding view model, provides placeholders for MyListingsView and MyOrdersView, and incorporates a dark-light mode settings view. Preferences for light/dark mode are now saved in local storage. It also fetches the user's name from Firebase to greet him in the profile view.

Important:
- Even though the Sign Out button is working, **it does not yet lead to the LoginView as it should**.
- Changes in Local Storage persist. If dark mode is enabled and the user closes the app, dark mode will continue active unless changed.
- New dark/light mode preferences do not break the existing time-aware dark and light mode, which is the default setting.

## Checklist
- [x] Referenced correct issue number.
- [x] Assigned to at least one reviewer.
- [x] Assigned asignee to the PR.
- [x] Appropriate labels applied.
- [x] Added to the Team-15-Kanban board.
- [x] Associated milestone with the PR.
- [x] Changes have been tested.
- [x] Documentation has been updated if necessary.
- [x] No new warnings or errors in the codebase.
- [x] UI changes (if any) have been attached as images/GIFs.

## Screenshots (if applicable)
<!-- Add any UI-related images or GIFs here. -->
![image](https://github.com/user-attachments/assets/40e90be1-77ed-4f1d-afd7-b98b99cd3e3f)

![image](https://github.com/user-attachments/assets/9cc54d69-c947-413c-a468-12750eea8779)

![image](https://github.com/user-attachments/assets/a7e3b324-fc0f-4ab5-af40-60525f250f65)

![image](https://github.com/user-attachments/assets/eb4c5363-29dc-41d9-ad7c-9ff8c6afe20a)


## Additional Notes
<!-- Any additional information or context regarding the PR. -->