### PR TITLE
 Save user theme preference to Firestore based on mode selection 

### DIFF
--- a/UniTrade/UniTrade/ModeSettings.swift
+++ b/UniTrade/UniTrade/ModeSettings.swift
@@ -6,18 +6,23 @@
 //
 
 import SwiftUI
+import FirebaseFirestore
+import FirebaseAuth
 
 class ModeSettings: ObservableObject {
     @Published var selectedMode: LightDarkModeSettingsView.Mode {
         didSet {
-            // Save the selected mode to UserDefaults whenever it changes
+            // Save selected mode to UserDefaults for persistence
             switch selectedMode {
             case .light:
                 UserDefaults.standard.set("light", forKey: "modeSetting")
+                updateFirestoreThemePreference(isAutomatic: false)
             case .dark:
                 UserDefaults.standard.set("dark", forKey: "modeSetting")
+                updateFirestoreThemePreference(isAutomatic: false)
             case .automatic:
                 UserDefaults.standard.set("automatic", forKey: "modeSetting")
+                updateFirestoreThemePreference(isAutomatic: true)
             }
         }
     }
@@ -37,6 +42,20 @@ class ModeSettings: ObservableObject {
             }
         } else {
             self.selectedMode = .automatic
+        }
+    }
+    
+    private func updateFirestoreThemePreference(isAutomatic: Bool) {
+        guard let userId = Auth.auth().currentUser?.uid else { return }
+        
+        let db = Firestore.firestore()
+        
+        db.collection("users").document(userId).setData(["time_aware_theme": isAutomatic], merge: true) { error in
+            if let error = error {
+                print("Error updating theme preference: \(error)")
+            } else {
+                print("Theme preference successfully updated.")
+            }
         }
     }
 }


### PR DESCRIPTION
## Description
This PR adds functionality to save each user’s theme mode preference to Firebase Firestore. The `time_aware_theme` field in the `users` collection is updated based on whether the user has selected an automatic, time-aware theme (`true`) or a manual light/dark theme (`false`).

**Changes include:**
- Updated `ModeSettings` class to trigger Firestore updates whenever the theme mode changes.
- Created a new `updateFirestoreThemePreference` function that saves the `time_aware_theme` boolean to Firestore.
- Ensured that the theme preference is correctly stored and retrieved from UserDefaults, maintaining user selection across app sessions.
  
This addition helps track user preferences, allowing insights into how many users rely on automatic mode vs. manual theme selection.

## Checklist
- [x] Referenced correct issue number.
- [x] Assigned to at least one reviewer.
- [x] Assigned assignee to the PR.
- [x] Appropriate labels applied.
- [x] Added to the Team-15-Kanban board.
- [x] Associated milestone with the PR.
- [x] Changes have been tested.
- [ ] Documentation has been updated if necessary.
- [x] No new warnings or errors in the codebase.
- [ ] UI changes (if any) have been attached as images/GIFs.

## Screenshots (if applicable)
<!-- Add any UI-related images or GIFs here. -->

## Additional Notes
This implementation assumes Firebase Authentication is properly configured and that the user is logged in. No significant changes to the UI were made, so no UI screenshots are required.
