### PR TITLE
Fix logout taking back to login view

### DIFF
--- a/UniTrade/UniTrade.xcodeproj/project.pbxproj
+++ b/UniTrade/UniTrade.xcodeproj/project.pbxproj
@@ -731,7 +731,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"UniTrade/Preview Content\"";
-				DEVELOPMENT_TEAM = 4AR68S8KC2;
+				DEVELOPMENT_TEAM = 6MG8GCGFUH;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = UniTrade/Info.plist;
@@ -748,7 +748,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = edu.uniandes.UniTrade.maru;
+				PRODUCT_BUNDLE_IDENTIFIER = edu.uniandes.UniTrade.fede;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -766,7 +766,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"UniTrade/Preview Content\"";
-				DEVELOPMENT_TEAM = 4AR68S8KC2;
+				DEVELOPMENT_TEAM = 6MG8GCGFUH;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = UniTrade/Info.plist;
@@ -783,7 +783,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = edu.uniandes.UniTrade.maru;
+				PRODUCT_BUNDLE_IDENTIFIER = edu.uniandes.UniTrade.fede;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/UniTrade/UniTrade/LoginView.swift
+++ b/UniTrade/UniTrade/LoginView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct LoginView: View {
     @ObservedObject var loginViewModel: LoginViewModel
+    @Binding var isSignedOut: Bool
     @StateObject private var screenTimeViewModel = ScreenTimeViewModel()
     @State private var isLoading = false // Loading state for the Login button
     @Environment(\.colorScheme) var colorScheme
@@ -33,8 +34,8 @@ struct LoginView: View {
                     if loginViewModel.isConnected {
                         isLoading = true
                         loginViewModel.signIn {
-                            // Callback after sign-in completes
                             isLoading = false
+                            isSignedOut = false
                         }
                     } else {
                         loginViewModel.showBanner = true // Show offline banner if not connected
@@ -92,13 +93,5 @@ struct LoginView: View {
         .onAppear {screenTimeViewModel.startTrackingTime()}
         .onDisappear {screenTimeViewModel.stopAndRecordTime(for: "LoginView")}
         .animation(.easeInOut, value: loginViewModel.showBanner && !loginViewModel.isConnected) // Animation for banner
-    }
-}
-
-struct LoginView_Previews: PreviewProvider {
-    static var vm = LoginViewModel()
-    
-    static var previews: some View {
-        LoginView(loginViewModel: vm)
     }
 }

--- a/UniTrade/UniTrade/ProfileView.swift
+++ b/UniTrade/UniTrade/ProfileView.swift
@@ -12,6 +12,7 @@ struct ProfileView: View {
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.presentationMode) var presentationMode
     @StateObject private var viewModel = ProfileViewModel()
+    @State private var isSignedOut = false
     @StateObject private var screenTimeViewModel = ScreenTimeViewModel()
     @StateObject private var loginViewModel = LoginViewModel()
     
@@ -85,6 +86,7 @@ struct ProfileView: View {
                 viewModel.signOut { success in
                     if success {
                         presentationMode.wrappedValue.dismiss()
+                        isSignedOut = true
                         print("Successfully signed out")
                     } else {
                         print("Failed to sign out")
@@ -99,6 +101,9 @@ struct ProfileView: View {
             }
             .disabled(viewModel.isSigningOut)
             .padding(.bottom, 20)
+        }
+        .fullScreenCover(isPresented: $isSignedOut) {
+            LoginView(loginViewModel: LoginViewModel(), isSignedOut: $isSignedOut)
         }
         .onAppear {
             viewModel.fetchUserName()

--- a/UniTrade/UniTrade/UniTradeApp.swift
+++ b/UniTrade/UniTrade/UniTradeApp.swift
@@ -27,6 +27,7 @@ struct UniTradeApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
     
     @StateObject var modeSettings = ModeSettings()
+    @State private var isSignedOut = false
     
     var sharedModelContainer: ModelContainer = {
         let schema = Schema()
@@ -62,7 +63,7 @@ struct UniTradeApp: App {
                         MainView(loginViewModel: loginViewModel)
                     }
                 } else {
-                    LoginView(loginViewModel: loginViewModel)
+                    LoginView(loginViewModel: loginViewModel, isSignedOut: $isSignedOut)
                 }
             }
             .onAppear {


### PR DESCRIPTION
# PR Title: [fix] Ensure navigation to LoginView after sign-out #45

## Description
This PR addresses an issue where the app remained on the `ProfileView` after the user signed out. To fix this, we introduced a new state variable, `isSignedOut`, to handle the navigation flow across different views:

- Added an `isSignedOut` state variable in `ProfileView` and `UniTradeApp`.
- Passed `isSignedOut` as a binding to `LoginView`, allowing it to reset after a successful sign-in, thus enabling navigation back to the main view.
- Adjusted the conditional view logic in `UniTradeApp` to display `LoginView` only when `isSignedOut` is `true` or no user is authenticated.
  
These changes provide a seamless navigation experience by directing users back to `LoginView` on sign-out and to the main app interface upon successful sign-in.

## Checklist
- [x] Referenced correct issue number (#45).
- [x] Assigned to at least one reviewer.
- [x] Assigned assignee to the PR.
- [x] Appropriate labels applied.
- [x] Added to the Team-15-Kanban board.
- [x] Associated milestone with the PR.
- [x] Changes have been tested.
- [x] Documentation has been updated if necessary.
- [x] No new warnings or errors in the codebase.
- [ ] UI changes (if any) have been attached as images/GIFs.

## Screenshots (if applicable)
<!-- No UI changes directly affected by this PR -->

## Additional Notes
This solution minimizes code changes and avoids major restructuring. Future improvements may involve centralizing user authentication state in a single, app-wide manager for easier navigation handling across views.
